### PR TITLE
support oauthPassThru

### DIFF
--- a/pkg/infinity/client.go
+++ b/pkg/infinity/client.go
@@ -108,6 +108,9 @@ func getRequest(settings InfinitySettings, body io.Reader, query Query, requestH
 	if settings.BasicAuthEnabled && (settings.UserName != "" || settings.Password != "") {
 		req.Header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(settings.UserName+":"+settings.Password)))
 	}
+	if settings.ForwardOauthIdentity {
+		req.Header.Add("Authorization", requestHeaders["Authorization"])
+	}
 	if query.Type == "json" || query.Type == "graphql" {
 		req.Header.Set("Content-Type", "application/json")
 	}

--- a/pkg/infinity/client_test.go
+++ b/pkg/infinity/client_test.go
@@ -151,6 +151,18 @@ func TestInfinityClient_GetResults(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "should respect oauthPassThru",
+			settings: infinity.InfinitySettings{
+				URL:                  "https://httpbin.org",
+				ForwardOauthIdentity: true,
+			},
+			query: infinity.Query{
+				URL:  "/bearer",
+				Type: "json",
+			},
+			wantO: map[string]interface{}(map[string]interface{}{"authenticated": true, "token": "123"}),
+		},
+		{
 			name:     "should return correct json",
 			settings: infinity.InfinitySettings{},
 			query: infinity.Query{
@@ -166,7 +178,9 @@ func TestInfinityClient_GetResults(t *testing.T) {
 				Settings:   tt.settings,
 				HttpClient: &http.Client{},
 			}
-			gotO, statusCode, duration, err := client.GetResults(tt.query, map[string]string{})
+			gotO, statusCode, duration, err := client.GetResults(tt.query, map[string]string{
+				"Authorization": "Bearer 123",
+			})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetResults() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/src/editors/config/Auth.tsx
+++ b/src/editors/config/Auth.tsx
@@ -8,7 +8,7 @@ type AuthType = 'none' | 'basicAuth' | 'oauthPassThru';
 const authTypes: Array<SelectableValue<AuthType>> = [
   { value: 'none', label: 'None' },
   { value: 'basicAuth', label: 'Basic Authentication' },
-  // { value: 'oauthPassThru', label: 'Forward OAuth' },
+  { value: 'oauthPassThru', label: 'Forward OAuth' },
 ];
 
 export const AuthEditor = (props: DataSourcePluginOptionsEditorProps<InfinityOptions>) => {


### PR DESCRIPTION
Support [oauthPassThru](https://grafana.com/docs/grafana/latest/developers/plugins/add-authentication-for-data-source-plugins/#forward-oauth-identity-for-the-logged-in-user). (see #246)